### PR TITLE
[ISS-24] only return True on non-negative results when comparing against PBs

### DIFF
--- a/src/logic/stats.js
+++ b/src/logic/stats.js
@@ -75,8 +75,9 @@ export const checkAgainstPersonalBest = (
 	personalBest
 ) => {
 	const func = isAverage ? average : best
-	const comparator = isAverage
+	const pbComparator = isAverage
 		? personalBest.average?.best
 		: personalBest.single?.best
-	return 1.3 * func(attempts, eventId, attempts.length) < comparator
+	const result = func(attempts, eventId, attempts.length)
+	return (1.3 * result < pbComparator) && (result >= 0)
 }


### PR DESCRIPTION
### Motivation
We currently raise an error if a user submits a DNF average.  We probably shouldn't do that, as it's not really accurate :)

**Addresses issue:** https://github.com/saranshgrover/cubing-at-home/issues/24

### Implementation
DNF's and DNS's are -1 and -2, resp; so add a check to compare against 0 as well.

It's been a bit since I've used js, sorry about any syntax mistakes.

### Additional thoughts
This doesn't handle the case where the cuber's PB is DNF and they get a non-DNF result (as `pbComparator < 0 < 1.3*result`), but that's not change to status quo; just wondering if we should even bother throwing up a message in that case?