### PR TITLE
fix minor typo in Redi Cube name

### DIFF
--- a/src/logic/consts.js
+++ b/src/logic/consts.js
@@ -98,7 +98,7 @@ export const activityKey = {
 	'2345relay': '2x2-5x5 Relay',
 	kilominx: 'Kilominx',
 	mpyram: 'Master Pyraminx',
-	redi: '-Redi Cube',
+	redi: 'Redi Cube',
 	'666bf': '6x6x6 Blindfolded',
 	'777bf': '7x7x7 Blindfolded',
 	miniguild: 'Mini Guildford Challenge',


### PR DESCRIPTION
Noticed a minor typo with the Redi Cube name, just wanted to fix it :)

![Redi Cube description is `-Redi Cube`](https://user-images.githubusercontent.com/8520179/87188129-24bc4f00-c2a3-11ea-9e31-9f083e72e750.png)