### PR TITLE
Remove pyraminx orientation warning

### DIFF
--- a/src/components/Competition/Compete/DrawScramble.tsx
+++ b/src/components/Competition/Compete/DrawScramble.tsx
@@ -44,9 +44,6 @@ export default function DrawScramble({
 					event={eventId === 'mirror' ? '333' : eventId}
 					scramble={scrambleParse}
 				/>
-				{eventId === 'pyram' && (
-					<Typography>Note: Pyraminx Orientation is incorrect. </Typography>
-				)}
 			</>
 		)
 	}


### PR DESCRIPTION
When competing in C@H 1.2, it seemed like the scramble picture matched all 5 solves - I'm guessing this was fixed in the last few weeks? :)

(If it hasn't and I just got exceedingly lucky, or if we wanted to keep the warning up just in case, feel free to close and delete branch.)